### PR TITLE
Make ExtendedTimeStep __getitem__ more robust

### DIFF
--- a/dmc.py
+++ b/dmc.py
@@ -29,7 +29,10 @@ class ExtendedTimeStep(NamedTuple):
         return self.step_type == StepType.LAST
 
     def __getitem__(self, attr):
-        return getattr(self, attr)
+        if isinstance(attr, str):
+            return getattr(self, attr)
+        else:
+            return tuple.__getitem__(self, attr)
 
 
 class ActionRepeatWrapper(dm_env.Environment):


### PR DESCRIPTION
I run into the following error running drqv2 training. I am not sure if it's caused by python version difference (I'm on python 3.7.11).
 
Traceback (most recent call last):
  File "train.py", line 229, in main
    workspace.train()
  File "/home/desaixiecvc/github/drqv2original/train.py", line 136, in train
    self.replay_storage.add(time_step)
  File "/home/desaixiecvc/github/drqv2original/replay_buffer.py", line 50, in add
    value = time_step[spec.name]
  File "/home/desaixiecvc/github/drqv2original/dmc.py", line 33, in __getitem__
    return getattr(self, attr)
  File "/home/desaixiecvc/github/drqv2original/dmc.py", line 33, in __getitem__
    return getattr(self, attr)
TypeError: getattr(): attribute name must be string

__getitem__ first get spec.name (a string) as attr, and returns the index of the attr in ExtendedTimeStep. Then, when retrieving the item with the index (int), __getitem__ gets called again with the index as attr, which caused the error. I added a type check on attr to solve this.