### PR TITLE
Update conda_env.yml to use git+https://

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytorch::torchaudio
   - pip:
     - termcolor==1.1.0
-    - git+git://github.com/deepmind/dm_control.git
+    - git+https://github.com/deepmind/dm_control.git
     - tb-nightly
     - imageio==2.9.0
     - imageio-ffmpeg==0.4.4


### PR DESCRIPTION
Fixes the error of not connecting to github.com when running the conda environment setup or pip installation.

Conda environment setup using `conda env create -f conda_env.yml` fails when it tries to `pip install git+git://github.com/deepmind/dm_control.git` with the message:

```
Cloning git://github.com/deepmind/dm_control.git to c:\users\austin\appdata\local\temp\pip-req-build-spf5f4dl
  Running command git clone -q git://github.com/deepmind/dm_control.git 'C:\Users\Austin\AppData\Local\Temp\pip-req-build-spf5f4dl'
  fatal: unable to connect to github.com:
  github.com[0: 192.30.255.113]: errno=Unknown error
```

I was able to get around this error by replacing `git+git://` with `git+https://`.